### PR TITLE
Run certstream-server in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD [ "python", "./run_server.py" ]

--- a/certstream/webserver.py
+++ b/certstream/webserver.py
@@ -66,7 +66,7 @@ class WebServer(object):
 
     async def redirect_ssl_if_needed(self, _, handler):
         async def middleware_handler(request):
-            if not request.host.startswith('127.0.0.1') and request.headers.get('X-Forwarded-Proto', 'http') == 'http':
+            if os.environ.get('NOSSL') == None and not request.host.startswith('127.0.0.1') and request.headers.get('X-Forwarded-Proto', 'http') == 'http':
                 return web.HTTPFound(request.url.with_scheme('https'))
             response = await handler(request)
             return response


### PR DESCRIPTION
This PR does two things:
- adds a Dockerfile to run in docker
- if an environment variable named NOSSL is present, never redirect to http to https

You can build the image with `docker build -t <you>/certstream` then run it with `docker run -d -p 8080:8080 -e NOSSL=true <you>/certstream`. Port 8080 is exposed.

The `NOSSL=true` option is for when certstream will not be run on 127.0.0.1 (eg. accessed from a linked container, or through docker swarm).