### PR TITLE
Use HTTPS for certificate logs

### DIFF
--- a/certstream/watcher.py
+++ b/certstream/watcher.py
@@ -76,7 +76,7 @@ class TransparencyWatcher(object):
             while not self.stopped:
                 try:
                     async with aiohttp.ClientSession(loop=self.loop) as session:
-                        async with session.get("http://{}/ct/v1/get-sth".format(operator_information['url'])) as response:
+                        async with session.get("https://{}/ct/v1/get-sth".format(operator_information['url'])) as response:
                             info = await response.json()
                 except aiohttp.ClientError as e:
                     self.logger.info('[{}] Exception -> {}'.format(name, e))
@@ -135,7 +135,7 @@ class TransparencyWatcher(object):
                 assert end >= start, "End {} is less than start {}!".format(end, start)
                 assert end < tree_size, "End {} is less than tree_size {}".format(end, tree_size)
 
-                url = "http://{}/ct/v1/get-entries?start={}&end={}".format(operator_information['url'], start, end)
+                url = "https://{}/ct/v1/get-entries?start={}&end={}".format(operator_information['url'], start, end)
 
                 async with session.get(url) as response:
                     certificates = await response.json()


### PR DESCRIPTION
According to [RFC 6962](https://tools.ietf.org/html/rfc6962), `Messages are sent as HTTPS GET or POST requests`.
For example, the ["Behind The Sofa" log](https://filippo.io/behindthesofa/) does not appear to be serving requests to port 80 at all:
```
$ wget -O- http://ct.filippo.io/behindthesofa/ct/v1/get-sth
--2017-12-28 22:43:31--  http://ct.filippo.io/behindthesofa/ct/v1/get-sth
Resolving ct.filippo.io (ct.filippo.io)... 2a07:1500:c1c1:c1c1:c1c1:c1c1:c1c1:c1c1
Connecting to ct.filippo.io (ct.filippo.io)|2a07:1500:c1c1:c1c1:c1c1:c1c1:c1c1:c1c1|:80... failed: Connection refused
```

Thus, this pull request aims to implement compatibility with logs which are only served via HTTPS.