### PR TITLE
Change documentation to require python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip3 install -r requirements.txt
 python3 run_server.py
 ```
 
-**Note** Running the server requires at least python 3.5, as we use the new `async`/`await` syntax internally.
+**Note** Running the server requires at least python 3.6, as we use the new `async`/`await` syntax internally.
 
 This will open up an http/websocket server on port 8080 (override this by setting a `PORT` environment variable). Connecting to it with a websocket client will subscribe you to a live aggregated stream of certificates and heartbeat messages. 
 


### PR DESCRIPTION
The server fails to run on python 3.5 with "yield inside async function"

```
$ python --version
Python 3.5.2
$ python run_server.py 
Traceback (most recent call last):
  File "run_server.py", line 1, in <module>
    import certstream
  File "certstream/__init__.py", line 9, in <module>
    from certstream.watcher import TransparencyWatcher
  File "certstream/watcher.py", line 148
    yield certificates['entries']
                       ^
SyntaxError: 'yield' inside async function
```